### PR TITLE
Changed to allow 8.x versions of puppetlabs/apt

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 8.0.0"
+      "version_requirement": ">= 2.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Changed to allow 8.x versions of puppetlabs/apt